### PR TITLE
Update README.md to specify Go1 & Go2 assets are available in forked MuJoCo MPC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For result videos and details, please checkout out our [paper](https://arxiv.org
 > 
 > ```zsh
 > git clone https://github.com/johnzhang3/mujoco_mpc -b go2
-> ```,
+> ```
 > 
 > respectively.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ For result videos and details, please checkout out our [paper](https://arxiv.org
 
 > [!NOTE]
 > MuJoCo MPC uses the Unitree A1 quadruped assets by default. For deployment with the Unitree Go1 or Go2, please clone MuJoCo MPC using either
+> 
 > ```zsh git clone https://github.com/johnzhang3/mujoco_mpc -b go1```
+> 
 > or
+> 
 > ```zsh git clone https://github.com/johnzhang3/mujoco_mpc -b go2```,
+> 
 > respectively.
 
 1. install the python interface for MuJoCo MPC following the [official instructions](https://github.com/google-deepmind/mujoco_mpc)

--- a/README.md
+++ b/README.md
@@ -9,11 +9,15 @@ For result videos and details, please checkout out our [paper](https://arxiv.org
 > [!NOTE]
 > MuJoCo MPC uses the Unitree A1 quadruped assets by default. For deployment with the Unitree Go1 or Go2, please clone MuJoCo MPC using either
 > 
-> ```zsh git clone https://github.com/johnzhang3/mujoco_mpc -b go1```
+> ```zsh
+> git clone https://github.com/johnzhang3/mujoco_mpc -b go1
+> ```
 > 
 > or
 > 
-> ```zsh git clone https://github.com/johnzhang3/mujoco_mpc -b go2```,
+> ```zsh
+> git clone https://github.com/johnzhang3/mujoco_mpc -b go2
+> ```,
 > 
 > respectively.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For result videos and details, please checkout out our [paper](https://arxiv.org
 
 ## Installation
 
-> [!NOTE]
+> [!WARNING]
 > MuJoCo MPC uses the Unitree A1 quadruped assets by default. For deployment with the Unitree Go1 or Go2, please clone MuJoCo MPC using either
 > 
 > ```zsh
@@ -18,8 +18,6 @@ For result videos and details, please checkout out our [paper](https://arxiv.org
 > ```zsh
 > git clone https://github.com/johnzhang3/mujoco_mpc -b go2
 > ```
-> 
-> respectively.
 
 1. install the python interface for MuJoCo MPC following the [official instructions](https://github.com/google-deepmind/mujoco_mpc)
 2. install necessary [Unitree SDK](https://github.com/unitreerobotics/unitree_legged_sdk) or [Unitree SDK2](https://github.com/unitreerobotics/unitree_sdk2) dependecies

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For result videos and details, please checkout out our [paper](https://arxiv.org
 
 ## Installation
 
-> [!WARNING]
+> [!NOTE]
 > MuJoCo MPC uses the Unitree A1 quadruped assets by default. For deployment with the Unitree Go1 or Go2, please clone MuJoCo MPC using either
 > 
 > ```zsh

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ For result videos and details, please checkout out our [paper](https://arxiv.org
 
 ## Installation
 
+> [!NOTE]
+> MuJoCo MPC uses the Unitree A1 quadruped assets by default. For deployment with the Unitree Go1 or Go2, please clone MuJoCo MPC using either
+> ```zsh git clone https://github.com/johnzhang3/mujoco_mpc -b go1```
+> or
+> ```zsh git clone https://github.com/johnzhang3/mujoco_mpc -b go2```,
+> respectively.
+
 1. install the python interface for MuJoCo MPC following the [official instructions](https://github.com/google-deepmind/mujoco_mpc)
 2. install necessary [Unitree SDK](https://github.com/unitreerobotics/unitree_legged_sdk) or [Unitree SDK2](https://github.com/unitreerobotics/unitree_sdk2) dependecies
 3. the estimation module is still under development. for now, we use optitrack and communciate using ROS. in principle, you can use any mocap or onboard estimation module.


### PR DESCRIPTION
This pull request only modifies the installation instructions to clarify that the Go1 and Go2 assets are not available in the official MuJoCo MPC installation instructions as specified in the current first step : `1. install the python interface for MuJoCo MPC following the official instructions.`